### PR TITLE
PAI-2050-update-kms-metrics-stat

### DIFF
--- a/modules/usage_alarms/main.tf
+++ b/modules/usage_alarms/main.tf
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_metric_alarm" "main" {
         "Class"    = each.value["class"]
         "Resource" = each.value["resource"]
         "Service"  = each.value["service_name"]
-        "Type"     = "Resource"
+        "Type"     = startswith(each.value["resource"], "CryptographicOperations") ? "API" : "Resource"
       }
       metric_name = startswith(each.value["resource"], "CryptographicOperations") ? "CallCount" : "ResourceCount"
       namespace   = "AWS/Usage"

--- a/modules/usage_alarms/main.tf
+++ b/modules/usage_alarms/main.tf
@@ -116,7 +116,7 @@ resource "aws_cloudwatch_metric_alarm" "main" {
         "Service"  = each.value["service_name"]
         "Type"     = "Resource"
       }
-      metric_name = "ResourceCount"
+      metric_name = startswith(each.value["resource"], "CryptographicOperations") ? "CallCount" : "ResourceCount"
       namespace   = "AWS/Usage"
       period      = 300
       stat        = each.value["resource"] == "NumberOfMessagesPublishedPerAccount" ? "Sum" : "Maximum"

--- a/modules/usage_alarms/main.tf
+++ b/modules/usage_alarms/main.tf
@@ -56,7 +56,9 @@ locals {
       ]
     }
     SNS = {
-      None = ["NumberOfMessagesPublishedPerAccount"]
+      None = [
+        "NumberOfMessagesPublishedPerAccount"
+      ]
     }
   }
 
@@ -84,6 +86,8 @@ locals {
       resource     = item.resource
     }
   }
+
+  metrics_with_sum_Statistic = ["NumberOfMessagesPublishedPerAccount", "CryptographicOperationsRsa", "CryptographicOperationsSymmetric" ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "main" {
@@ -119,7 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "main" {
       metric_name = startswith(each.value["resource"], "CryptographicOperations") ? "CallCount" : "ResourceCount"
       namespace   = "AWS/Usage"
       period      = 300
-      stat        = each.value["resource"] == "NumberOfMessagesPublishedPerAccount" ? "Sum" : "Maximum"
+      stat        = contains(local.metrics_with_sum_Statistic, each.value["resource"]) ? "Sum" : "Maximum"
     }
   }
 }

--- a/modules/usage_alarms/main.tf
+++ b/modules/usage_alarms/main.tf
@@ -87,7 +87,7 @@ locals {
     }
   }
 
-  metrics_with_sum_Statistic = ["NumberOfMessagesPublishedPerAccount", "CryptographicOperationsRsa", "CryptographicOperationsSymmetric" ]
+  metrics_with_sum_Statistic = ["NumberOfMessagesPublishedPerAccount", "CryptographicOperationsRsa", "CryptographicOperationsSymmetric"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "main" {

--- a/modules/usage_alarms/main.tf
+++ b/modules/usage_alarms/main.tf
@@ -1,6 +1,6 @@
 
 locals {
-  service_limits = {
+  service_limits = merge(var.dp_services, {
     # Format:
     #   <service name> = {
     #     <limit class> = [<service limit>]
@@ -52,7 +52,7 @@ locals {
     SNS = {
       None = ["NumberOfMessagesPublishedPerAccount"]
     }
-  }
+  })
 
   # for region in var.regions : region => [for metric in local.metrics_normalized_all : metric if metric.region == region && metric.service_name == service_name]
 

--- a/modules/usage_alarms/main.tf
+++ b/modules/usage_alarms/main.tf
@@ -1,6 +1,6 @@
 
 locals {
-  service_limits = merge(var.dp_services, {
+  service_limits = {
     # Format:
     #   <service name> = {
     #     <limit class> = [<service limit>]
@@ -49,10 +49,16 @@ locals {
     Firehose = {
       None = ["DeliveryStreams"]
     }
+    KMS = {
+      None = [
+        "CryptographicOperationsRsa",
+        "CryptographicOperationsSymmetric"
+      ]
+    }
     SNS = {
       None = ["NumberOfMessagesPublishedPerAccount"]
     }
-  })
+  }
 
   # for region in var.regions : region => [for metric in local.metrics_normalized_all : metric if metric.region == region && metric.service_name == service_name]
 

--- a/modules/usage_alarms/variables.tf
+++ b/modules/usage_alarms/variables.tf
@@ -36,6 +36,6 @@ variable "tags" {
 
 variable "dp_services" {
   description = "AWS Usage metrics to monitor"
-  type        = map(list(string))
+  type        = map(map(list(string)))
   default     = {}
 }

--- a/modules/usage_alarms/variables.tf
+++ b/modules/usage_alarms/variables.tf
@@ -33,3 +33,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "dp_services" {
+  description = "AWS Usage metrics to monitor"
+  type        = map(list(string))
+  default     = {}
+}

--- a/modules/usage_alarms/variables.tf
+++ b/modules/usage_alarms/variables.tf
@@ -33,9 +33,3 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
-
-variable "dp_services" {
-  description = "AWS Usage metrics to monitor"
-  type        = map(map(list(string)))
-  default     = {}
-}


### PR DESCRIPTION
fix KMS metrics stats to be sum instead of Maximum to reflect the same monitor used by service quota service